### PR TITLE
Improve GUI defaults and tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ weights/**/*.pth
 logs/
 *.log
 .conda/
+options/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Lynx
 
-Local YouTube Upscaling toolkit using Real-ESRGAN and NVENC.
+Local YouTube upscaling toolkit using Real‑ESRGAN and NVENC.  The
+application ships with a PyQt5 interface that stores its settings in
+`options/settings.json`.
 
 ## Quick start
 
@@ -14,6 +16,9 @@ Local YouTube Upscaling toolkit using Real-ESRGAN and NVENC.
    ```bash
    python main.py
    ```
+   On launch the window shows a status box indicating whether CUDA and
+   required weights are detected. If something is missing, follow the
+   instructions in the log output.
 
 ## Directory layout
 

--- a/lynx/__init__.py
+++ b/lynx/__init__.py
@@ -1,9 +1,13 @@
 """Lynx video upscaling package."""
 
 from .compat import patch_torchvision
+from .logger import get_logger
 
 # Apply compatibility shims at import time
 patch_torchvision()
+
+# Initialize shared logger early
+logger = get_logger()
 
 __all__ = [
     "download",

--- a/lynx/download.py
+++ b/lynx/download.py
@@ -45,6 +45,7 @@ def yt_download(
     if log_cb:
         log_cb("Downloading YouTube source…")
 
+    # yt-dlp expects flat lists for postprocessor_args; avoid nested lists
     ydl_opts = {
         "paths": {"home": str(downloads_dir)},
         "outtmpl": "%(title).200B [%(id)s].%(ext)s",
@@ -55,7 +56,7 @@ def yt_download(
         "no_warnings": True,
         "cachedir": False,
         "concurrent_fragment_downloads": 8,
-        "postprocessor_args": [["-nostdin"]],
+        "postprocessor_args": {"Merger": ["-nostdin"]},
         "overwrites": True,
         "progress_hooks": [hook],
     }

--- a/lynx/gui.py
+++ b/lynx/gui.py
@@ -8,6 +8,10 @@ from typing import Optional
 import customtkinter as ctk
 import tkinter as tk
 from tkinter import filedialog, messagebox
+import logging
+from .logger import get_logger
+
+logger = get_logger()
 
 
 class Tooltip:
@@ -79,6 +83,7 @@ def preload(root: ctk.CTk) -> bool:
     Returns ``True`` if startup completed, ``False`` if cancelled.
     """
 
+    logger.info("Performing startup checks")
     cancel_event = threading.Event()
     splash = SplashScreen(root, cancel_event)
 
@@ -126,6 +131,7 @@ def preload(root: ctk.CTk) -> bool:
         return False
 
     splash.update("Starting UI…", 100)
+    logger.info("Startup checks complete")
     splash.close()
     return True
 
@@ -256,6 +262,7 @@ class App:
         self.apply_options()
 
     def log(self, msg: str) -> None:
+        logger.info(msg)
         self.txt_log.insert("end", msg + "\n")
         self.txt_log.see("end")
         self.root.update_idletasks()
@@ -410,8 +417,10 @@ class App:
             cfg = self.collect_cfg()
         except Exception as e:
             messagebox.showerror("Invalid settings", str(e))
+            logger.error("Invalid settings: %s", e)
             return
 
+        logger.info("Starting processing")
         self.btn_run.config(state="disabled")
         self.btn_cancel.config(state="normal")
         self.set_status("Starting…")
@@ -427,12 +436,14 @@ class App:
         if self.processor:
             self.processor.cancel()
             self.set_status("Cancelling…")
+            logger.info("Cancel requested")
         self.btn_cancel.config(state="disabled")
         self.btn_run.config(state="normal")
 
 
 def main() -> None:
     ctk.set_appearance_mode("Dark")
+    logger.info("Launching GUI")
     root = ctk.CTk()
     root.withdraw()
     if not preload(root):

--- a/lynx/gui.py
+++ b/lynx/gui.py
@@ -451,16 +451,30 @@ def main() -> None:
     logger.info("Launching GUI")
     root = ctk.CTk()
     root.withdraw()
+
+    def report_callback_exception(exc: type[BaseException], val: BaseException, tb: object) -> None:
+        logger.exception("Tkinter callback error", exc_info=(exc, val, tb))
+        messagebox.showerror("Error", f"{exc.__name__}: {val}")
+
+    root.report_callback_exception = report_callback_exception  # type: ignore[attr-defined]
+
     if not preload(root):
+        logger.info("Startup cancelled")
         root.destroy()
         return
+
     root.deiconify()
     root.lift()
     root.attributes("-topmost", True)
     root.after(0, root.attributes, "-topmost", False)
+    root.protocol("WM_DELETE_WINDOW", root.destroy)
     app = App(root)
     root.minsize(720, 600)
-    root.mainloop()
+    logger.info("Entering mainloop")
+    try:
+        root.mainloop()
+    finally:
+        logger.info("GUI closed")
 
 
 if __name__ == "__main__":

--- a/lynx/gui.py
+++ b/lynx/gui.py
@@ -1,448 +1,286 @@
-"""Tkinter GUI for the Lynx upscaler."""
+"""PyQt5 GUI for the Lynx upscaler."""
 from __future__ import annotations
 
+import logging
+import sys
 import threading
 from pathlib import Path
 from typing import Optional
 
-try:
-    import customtkinter as ctk
-except Exception as e:  # pragma: no cover - import failure check
-    raise RuntimeError(
-        "customtkinter is required for the GUI. Install it with 'pip install customtkinter'."
-    ) from e
-import tkinter as tk
-from tkinter import filedialog, messagebox
-import logging
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+from .processor import Processor
+from .options import load_options, save_options, DEFAULTS
 from .logger import get_logger
 
 logger = get_logger()
 
 
-class Tooltip:
-    """Simple tooltip for widgets."""
+class LogHandler(logging.Handler):
+    """Forward log records to a ``QPlainTextEdit``."""
 
-    def __init__(self, widget: ctk.CTkBaseClass, text: str) -> None:
+    def __init__(self, widget: QtWidgets.QPlainTextEdit) -> None:
+        super().__init__()
         self.widget = widget
-        self.text = text
-        self.tip: Optional[ctk.CTkToplevel] = None
-        widget.bind("<Enter>", self.show)
-        widget.bind("<Leave>", self.hide)
 
-    def show(self, _event: object | None = None) -> None:
-        if self.tip or not self.text:
-            return
-        x = self.widget.winfo_rootx() + 20
-        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 10
-        self.tip = ctk.CTkToplevel(self.widget)
-        self.tip.wm_overrideredirect(True)
-        self.tip.wm_geometry(f"+{x}+{y}")
-        ctk.CTkLabel(self.tip, text=self.text, fg_color="#ffffe0", text_color="black", corner_radius=2).pack(padx=4, pady=2)
-
-    def hide(self, _event: object | None = None) -> None:
-        if self.tip:
-            self.tip.destroy()
-            self.tip = None
-
-import subprocess
-from .processor import Processor
-from .models import ensure_model
-from .options import load_options, save_options, DEFAULTS
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - UI
+        msg = self.format(record)
+        self.widget.appendPlainText(msg)
+        self.widget.verticalScrollBar().setValue(
+            self.widget.verticalScrollBar().maximum()
+        )
 
 
-class SplashScreen:
-    """Simple splash window with status text, progress bar and cancel."""
+class OptionsDialog(QtWidgets.QDialog):
+    """Dialog for editing persistent options."""
 
-    def __init__(self, root: ctk.CTk, cancel_event: threading.Event) -> None:
-        self.cancel_event = cancel_event
-        self.top = ctk.CTkToplevel(root)
-        self.top.title("Lynx Loading")
-        self.top.resizable(False, False)
-        self.top.geometry("360x120")
-        self.top.attributes("-topmost", True)
-        self.var_msg = ctk.StringVar(value="Starting…")
-        ctk.CTkLabel(self.top, textvariable=self.var_msg).pack(pady=10)
-        self.bar = ctk.CTkProgressBar(self.top, width=300)
-        self.bar.pack(pady=10)
-        self.bar.set(0)
-        ctk.CTkButton(self.top, text="Cancel", command=self.cancel).pack(pady=(0, 8))
-        self.top.update()
+    def __init__(self, opts: dict, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Options")
+        self.opts = opts.copy()
+        self._init_ui()
 
-    def update(self, msg: str, value: int) -> None:
-        self.var_msg.set(msg)
-        self.bar.set(value / 100)
-        self.top.update_idletasks()
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        tabs = QtWidgets.QTabWidget()
+        layout.addWidget(tabs)
+        paths = QtWidgets.QWidget()
+        enc = QtWidgets.QWidget()
+        tabs.addTab(paths, "Paths")
+        tabs.addTab(enc, "Encoding")
 
-    def cancel(self) -> None:
-        self.cancel_event.set()
-        self.var_msg.set("Cancelling…")
-        self.top.update()
+        form_paths = QtWidgets.QFormLayout(paths)
+        form_enc = QtWidgets.QFormLayout(enc)
 
-    def close(self) -> None:
-        self.top.destroy()
+        self.ed_out = QtWidgets.QLineEdit(self.opts.get("output", DEFAULTS["output"]))
+        self.ed_weights = QtWidgets.QLineEdit(
+            self.opts.get("weights_dir", DEFAULTS["weights_dir"])
+        )
+        self.ed_work = QtWidgets.QLineEdit(self.opts.get("workdir", DEFAULTS["workdir"]))
+        form_paths.addRow("Default output", self.ed_out)
+        form_paths.addRow("Weights folder", self.ed_weights)
+        form_paths.addRow("Work folder", self.ed_work)
+
+        self.sp_w = QtWidgets.QSpinBox()
+        self.sp_w.setRange(64, 16384)
+        self.sp_w.setValue(int(self.opts.get("target_width", DEFAULTS["target_width"])))
+        self.sp_h = QtWidgets.QSpinBox()
+        self.sp_h.setRange(64, 16384)
+        self.sp_h.setValue(int(self.opts.get("target_height", DEFAULTS["target_height"])))
+        self.sp_tile = QtWidgets.QSpinBox()
+        self.sp_tile.setRange(16, 1024)
+        self.sp_tile.setValue(int(self.opts.get("tile", DEFAULTS["tile"])))
+        self.sp_cq = QtWidgets.QSpinBox()
+        self.sp_cq.setRange(0, 51)
+        self.sp_cq.setValue(int(self.opts.get("cq", DEFAULTS["cq"])))
+        self.cmb_codec = QtWidgets.QComboBox()
+        self.cmb_codec.addItems(["hevc_nvenc", "h264_nvenc"])
+        self.cmb_codec.setCurrentText(self.opts.get("codec", DEFAULTS["codec"]))
+        self.cmb_preset = QtWidgets.QComboBox()
+        self.cmb_preset.addItems([f"p{i}" for i in range(1, 8)])
+        self.cmb_preset.setCurrentText(self.opts.get("preset", DEFAULTS["preset"]))
+        self.chk_fp16 = QtWidgets.QCheckBox()
+        self.chk_fp16.setChecked(bool(self.opts.get("use_fp16", DEFAULTS["use_fp16"])))
+        self.chk_keep = QtWidgets.QCheckBox()
+        self.chk_keep.setChecked(bool(self.opts.get("keep_temps", DEFAULTS["keep_temps"])))
+        self.chk_prefetch = QtWidgets.QCheckBox()
+        self.chk_prefetch.setChecked(bool(self.opts.get("prefetch_models", DEFAULTS["prefetch_models"])))
+        self.chk_strict = QtWidgets.QCheckBox()
+        self.chk_strict.setChecked(bool(self.opts.get("strict_model_hash", DEFAULTS["strict_model_hash"])))
+
+        form_enc.addRow("Width", self.sp_w)
+        form_enc.addRow("Height", self.sp_h)
+        form_enc.addRow("Tile", self.sp_tile)
+        form_enc.addRow("CQ", self.sp_cq)
+        form_enc.addRow("Codec", self.cmb_codec)
+        form_enc.addRow("Preset", self.cmb_preset)
+        form_enc.addRow("Use FP16", self.chk_fp16)
+        form_enc.addRow("Keep temp files", self.chk_keep)
+        form_enc.addRow("Prefetch models", self.chk_prefetch)
+        form_enc.addRow("Verify model hash", self.chk_strict)
+
+        btn_row = QtWidgets.QHBoxLayout()
+        layout.addLayout(btn_row)
+        btn_row.addStretch(1)
+        btn_defaults = QtWidgets.QPushButton("Defaults")
+        btn_save = QtWidgets.QPushButton("Save")
+        btn_close = QtWidgets.QPushButton("Close")
+        btn_row.addWidget(btn_defaults)
+        btn_row.addWidget(btn_save)
+        btn_row.addWidget(btn_close)
+        btn_defaults.clicked.connect(self.set_defaults)
+        btn_save.clicked.connect(self.accept)
+        btn_close.clicked.connect(self.reject)
+
+    def set_defaults(self) -> None:
+        self.ed_out.setText(DEFAULTS["output"])
+        self.ed_weights.setText(DEFAULTS["weights_dir"])
+        self.ed_work.setText(DEFAULTS["workdir"])
+        self.sp_w.setValue(int(DEFAULTS["target_width"]))
+        self.sp_h.setValue(int(DEFAULTS["target_height"]))
+        self.sp_tile.setValue(int(DEFAULTS["tile"]))
+        self.sp_cq.setValue(int(DEFAULTS["cq"]))
+        self.cmb_codec.setCurrentText(DEFAULTS["codec"])
+        self.cmb_preset.setCurrentText(DEFAULTS["preset"])
+        self.chk_fp16.setChecked(bool(DEFAULTS["use_fp16"]))
+        self.chk_keep.setChecked(bool(DEFAULTS["keep_temps"]))
+        self.chk_prefetch.setChecked(bool(DEFAULTS["prefetch_models"]))
+        self.chk_strict.setChecked(bool(DEFAULTS["strict_model_hash"]))
+
+    def accept(self) -> None:  # pragma: no cover - UI
+        self.opts["output"] = self.ed_out.text().strip()
+        self.opts["weights_dir"] = self.ed_weights.text().strip()
+        self.opts["workdir"] = self.ed_work.text().strip()
+        self.opts["target_width"] = self.sp_w.value()
+        self.opts["target_height"] = self.sp_h.value()
+        self.opts["tile"] = self.sp_tile.value()
+        self.opts["cq"] = self.sp_cq.value()
+        self.opts["codec"] = self.cmb_codec.currentText()
+        self.opts["preset"] = self.cmb_preset.currentText()
+        self.opts["use_fp16"] = self.chk_fp16.isChecked()
+        self.opts["keep_temps"] = self.chk_keep.isChecked()
+        self.opts["prefetch_models"] = self.chk_prefetch.isChecked()
+        self.opts["strict_model_hash"] = self.chk_strict.isChecked()
+        save_options(self.opts)
+        logger.debug("Options saved: %s", self.opts)
+        super().accept()
 
 
-def preload(root: ctk.CTk) -> bool:
-    """Show a temporary splash screen while verifying runtime.
-
-    Returns ``True`` if startup completed, ``False`` if cancelled.
-    """
-
-    logger.info("Performing startup checks")
-    cancel_event = threading.Event()
-    splash = SplashScreen(root, cancel_event)
-
-    # 1. Check FFmpeg
-    splash.update("Checking FFmpeg…", 10)
-    try:
-        subprocess.run(["ffmpeg", "-version"], stdout=subprocess.DEVNULL,
-                       stderr=subprocess.DEVNULL, check=True)
-    except Exception:
-        pass
-    if cancel_event.is_set():
-        splash.close()
-        return False
-
-    # 2. Ensure models exist (download if needed)
-    weights = Path("weights")
-    for idx, model in enumerate(["RealESRGAN_x2plus.pth", "RealESRGAN_x4plus.pth"]):
-        if cancel_event.is_set():
-            splash.close()
-            return False
-
-        splash.update(f"Loading {model}…", 30 + idx * 30)
-
-        def prog(d: int, t: int, base: int = idx) -> None:
-            splash.update(
-                f"Loading {model}…",
-                30 + base * 30 + int((d / (t or 1)) * 30),
-            )
-
-        try:
-            ensure_model(
-                weights,
-                model,
-                progress_cb=prog,
-                cancel_event=cancel_event,
-            )
-        except Exception:
-            if cancel_event.is_set():
-                splash.close()
-                return False
-            continue
-
-    if cancel_event.is_set():
-        splash.close()
-        return False
-
-    splash.update("Starting UI…", 100)
-    logger.info("Startup checks complete")
-    splash.close()
-    return True
-
-
-class App:
+class MainWindow(QtWidgets.QMainWindow):
     """Main application window."""
 
-    def __init__(self, root: ctk.CTk) -> None:
-        self.root = root
-        root.title("Lynx Upscaler")
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Lynx Upscaler")
         self.processor: Optional[Processor] = None
+        self.thread: Optional[threading.Thread] = None
         self.opts = load_options()
         logger.debug("Options loaded: %s", self.opts)
+        self._init_ui()
 
-        menubar = tk.Menu(root)
-        opt_menu = tk.Menu(menubar, tearoff=0)
-        opt_menu.add_command(label="Options", command=self.open_options)
-        menubar.add_cascade(label="Settings", menu=opt_menu)
-        root.config(menu=menubar)
+    # UI construction
+    def _init_ui(self) -> None:
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        layout = QtWidgets.QVBoxLayout(central)
 
-        pad = {"padx": 6, "pady": 2}
+        form_in = QtWidgets.QHBoxLayout()
+        layout.addLayout(form_in)
+        self.ed_in = QtWidgets.QLineEdit()
+        form_in.addWidget(QtWidgets.QLabel("Video file or YouTube link:"))
+        form_in.addWidget(self.ed_in)
+        btn_in = QtWidgets.QPushButton("Browse")
+        form_in.addWidget(btn_in)
+        btn_in.clicked.connect(self.browse_input)
 
-        col1 = ctk.CTkFrame(root)
-        col1.pack(fill="both", expand=True)
+        form_out = QtWidgets.QHBoxLayout()
+        layout.addLayout(form_out)
+        self.ed_out = QtWidgets.QLineEdit(self.opts.get("output", DEFAULTS["output"]))
+        form_out.addWidget(QtWidgets.QLabel("Save output to:"))
+        form_out.addWidget(self.ed_out)
+        btn_out = QtWidgets.QPushButton("Browse")
+        form_out.addWidget(btn_out)
+        btn_out.clicked.connect(self.browse_output)
 
-        frm_in = ctk.CTkFrame(col1)
-        frm_in.pack(fill="x", **pad)
-        self.var_input = ctk.StringVar()
-        lbl_in = ctk.CTkLabel(frm_in, text="Video file or YouTube link:")
-        lbl_in.pack(anchor="w")
-        ent_in = ctk.CTkEntry(frm_in, textvariable=self.var_input, width=400)
-        ent_in.pack(side="left", fill="x", expand=True)
-        btn_in = ctk.CTkButton(frm_in, text="Browse", command=self.browse_input)
-        btn_in.pack(side="left")
-        Tooltip(ent_in, "Choose a local video or paste a YouTube URL")
+        self.bar_dl = QtWidgets.QProgressBar()
+        self.bar_proc = QtWidgets.QProgressBar()
+        layout.addWidget(QtWidgets.QLabel("Download progress"))
+        layout.addWidget(self.bar_dl)
+        layout.addWidget(QtWidgets.QLabel("Process progress"))
+        layout.addWidget(self.bar_proc)
 
-        frm_out = ctk.CTkFrame(col1)
-        frm_out.pack(fill="x", **pad)
-        self.var_output = ctk.StringVar(value=self.opts.get("output", DEFAULTS["output"]))
-        lbl_out = ctk.CTkLabel(frm_out, text="Save output to:")
-        lbl_out.pack(anchor="w")
-        ent_out = ctk.CTkEntry(frm_out, textvariable=self.var_output, width=400)
-        ent_out.pack(side="left", fill="x", expand=True)
-        btn_out = ctk.CTkButton(frm_out, text="Browse", command=self.browse_output)
-        btn_out.pack(side="left")
-        Tooltip(ent_out, "Destination video file")
+        self.log_widget = QtWidgets.QPlainTextEdit(readOnly=True)
+        layout.addWidget(self.log_widget, stretch=1)
 
-        frm_w = ctk.CTkFrame(col1)
-        frm_w.pack(fill="x", **pad)
-        self.var_w = ctk.IntVar(value=int(self.opts.get("target_width", DEFAULTS["target_width"])))
-        self.var_h = ctk.IntVar(value=int(self.opts.get("target_height", DEFAULTS["target_height"])))
-        ctk.CTkLabel(frm_w, text="Output width").grid(row=0, column=0, sticky="e")
-        ent_w = ctk.CTkEntry(frm_w, textvariable=self.var_w, width=80)
-        ent_w.grid(row=0, column=1, sticky="w")
-        ctk.CTkLabel(frm_w, text="Height").grid(row=0, column=2, sticky="e")
-        ent_h = ctk.CTkEntry(frm_w, textvariable=self.var_h, width=80)
-        ent_h.grid(row=0, column=3, sticky="w")
-        Tooltip(ent_w, "Desired output width in pixels")
-        Tooltip(ent_h, "Desired output height in pixels")
+        btn_row = QtWidgets.QHBoxLayout()
+        layout.addLayout(btn_row)
+        self.btn_start = QtWidgets.QPushButton("Start")
+        self.btn_cancel = QtWidgets.QPushButton("Cancel")
+        self.btn_cancel.setEnabled(False)
+        btn_row.addWidget(self.btn_start)
+        btn_row.addWidget(self.btn_cancel)
+        self.btn_start.clicked.connect(self.start)
+        self.btn_cancel.clicked.connect(self.cancel)
 
-        frm_paths = ctk.CTkFrame(col1)
-        frm_paths.pack(fill="x", **pad)
-        self.var_weights = ctk.StringVar(value=self.opts.get("weights_dir", DEFAULTS["weights_dir"]))
-        self.var_work = ctk.StringVar(value=self.opts.get("workdir", DEFAULTS["workdir"]))
-        ctk.CTkLabel(frm_paths, text="Model folder").grid(row=0, column=0, sticky="e")
-        self.cmb_weights = ctk.CTkComboBox(frm_paths, variable=self.var_weights, values=["Browse…"], width=200, state="readonly")
-        self.cmb_weights.grid(row=0, column=1, sticky="w")
-        self.cmb_weights.bind("<<ComboboxSelected>>", self.browse_weights)
-        Tooltip(self.cmb_weights, "Where model weights are stored")
-        ctk.CTkLabel(frm_paths, text="Work folder").grid(row=1, column=0, sticky="e")
-        self.cmb_work = ctk.CTkComboBox(frm_paths, variable=self.var_work, values=["Browse…"], width=200, state="readonly")
-        self.cmb_work.grid(row=1, column=1, sticky="w")
-        self.cmb_work.bind("<<ComboboxSelected>>", self.browse_work)
-        Tooltip(self.cmb_work, "Temporary working directory")
+        self.status_label = QtWidgets.QLabel("Idle")
+        self.statusBar().addWidget(self.status_label)
 
-        frm_set = ctk.CTkFrame(col1)
-        frm_set.pack(fill="x", **pad)
-        ctk.CTkLabel(frm_set, text="Settings").grid(row=0, column=0, sticky="w", pady=(2, 6))
+        menu = self.menuBar().addMenu("Settings")
+        act_opts = menu.addAction("Options")
+        act_opts.triggered.connect(self.open_options)
 
-        self.var_tile = ctk.IntVar(value=int(self.opts.get("tile", DEFAULTS["tile"])))
-        self.var_cq = ctk.IntVar(value=int(self.opts.get("cq", DEFAULTS["cq"])))
-        self.var_codec = ctk.StringVar(value=self.opts.get("codec", DEFAULTS["codec"]))
-        self.var_preset = ctk.StringVar(value=self.opts.get("preset", DEFAULTS["preset"]))
-        self.var_fp16 = ctk.BooleanVar(value=bool(self.opts.get("use_fp16", DEFAULTS["use_fp16"])))
-        self.var_keep_temps = ctk.BooleanVar(value=bool(self.opts.get("keep_temps", DEFAULTS["keep_temps"])))
-        self.var_prefetch = ctk.BooleanVar(value=bool(self.opts.get("prefetch_models", DEFAULTS["prefetch_models"])))
-        self.var_strict_hash = ctk.BooleanVar(value=bool(self.opts.get("strict_model_hash", DEFAULTS["strict_model_hash"])))
-
-        ctk.CTkLabel(frm_set, text="Tile").grid(row=1, column=0, sticky="e")
-        ctk.CTkEntry(frm_set, width=60, textvariable=self.var_tile).grid(row=1, column=1, sticky="w")
-
-        ctk.CTkLabel(frm_set, text="CQ").grid(row=1, column=2, sticky="e")
-        ctk.CTkEntry(frm_set, width=60, textvariable=self.var_cq).grid(row=1, column=3, sticky="w")
-
-        ctk.CTkLabel(frm_set, text="Codec").grid(row=2, column=0, sticky="e")
-        ctk.CTkComboBox(frm_set, variable=self.var_codec, values=["hevc_nvenc", "h264_nvenc"], width=120, state="readonly").grid(row=2, column=1, sticky="w")
-
-        ctk.CTkLabel(frm_set, text="Preset").grid(row=2, column=2, sticky="e")
-        ctk.CTkComboBox(frm_set, variable=self.var_preset, values=[f"p{i}" for i in range(1, 8)], width=60, state="readonly").grid(row=2, column=3, sticky="w")
-
-        ctk.CTkCheckBox(frm_set, text="Use FP16 (RTX only)", variable=self.var_fp16).grid(row=3, column=0, sticky="w", pady=2)
-        ctk.CTkCheckBox(frm_set, text="Keep temp files", variable=self.var_keep_temps).grid(row=3, column=1, sticky="w")
-        ctk.CTkCheckBox(frm_set, text="Download models now", variable=self.var_prefetch).grid(row=3, column=2, sticky="w")
-        ctk.CTkCheckBox(frm_set, text="Verify model hash", variable=self.var_strict_hash).grid(row=3, column=3, sticky="w")
-
-        frm_prog = ctk.CTkFrame(col1)
-        frm_prog.pack(fill="x", **pad)
-        ctk.CTkLabel(frm_prog, text="Download progress").pack(anchor="w")
-        self.bar_dl = ctk.CTkProgressBar(frm_prog)
-        self.bar_dl.pack(fill="x")
-        self.bar_dl.set(0)
-        ctk.CTkLabel(frm_prog, text="Process progress").pack(anchor="w", pady=(8, 0))
-        self.bar_proc = ctk.CTkProgressBar(frm_prog)
-        self.bar_proc.pack(fill="x")
-        self.bar_proc.set(0)
-
-        self.var_status = ctk.StringVar(value="Idle")
-        ctk.CTkLabel(col1, textvariable=self.var_status).pack(anchor="w", **pad)
-        self.txt_log = ctk.CTkTextbox(col1, height=200)
-        self.txt_log.pack(fill="both", expand=True, **pad)
-
-        frm_btn = ctk.CTkFrame(col1)
-        frm_btn.pack(fill="x", **pad)
-        self.btn_run = ctk.CTkButton(frm_btn, text="Start", command=self.start)
-        self.btn_run.pack(side="left")
-        self.btn_cancel = ctk.CTkButton(frm_btn, text="Cancel", command=self.cancel, state="disabled")
-        self.btn_cancel.pack(side="left", padx=6)
-
-        self.apply_options()
+        # Attach logger to text widget
+        handler = LogHandler(self.log_widget)
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+        logging.getLogger("lynx").addHandler(handler)
         logger.debug("UI initialized")
+
+    # UI helper methods
+    def browse_input(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select input video")
+        if path:
+            self.ed_in.setText(path)
+
+    def browse_output(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save output as", str(Path("outputs") / "output.mp4"), "MP4 files (*.mp4)"
+        )
+        if path:
+            self.ed_out.setText(path)
+
+    def open_options(self) -> None:
+        dlg = OptionsDialog(self.opts, self)
+        if dlg.exec_() == QtWidgets.QDialog.Accepted:
+            self.opts = dlg.opts
+            save_options(self.opts)
+            self.apply_options()
+
+    def apply_options(self) -> None:
+        self.ed_out.setText(self.opts.get("output", DEFAULTS["output"]))
 
     def log(self, msg: str) -> None:
         logger.info(msg)
-        self.txt_log.insert("end", msg + "\n")
-        self.txt_log.see("end")
-        self.root.update_idletasks()
 
     def set_progress(self, which: str, done: int, total: int) -> None:
         if total <= 0:
             return
-        value = max(0, min(100, int(done * 100 / total)))
+        val = max(0, min(100, int(done * 100 / total)))
         if which == "download":
-            self.bar_dl.set(value / 100)
+            self.bar_dl.setValue(val)
         else:
-            self.bar_proc.set(value / 100)
-        self.root.update_idletasks()
+            self.bar_proc.setValue(val)
 
     def set_status(self, msg: str) -> None:
-        self.var_status.set(msg)
-        self.root.update_idletasks()
+        self.status_label.setText(msg)
 
-    def browse_input(self) -> None:
-        path = filedialog.askopenfilename(title="Select input video")
-        if path:
-            self.var_input.set(path)
-
-    def browse_output(self) -> None:
-        path = filedialog.asksaveasfilename(title="Save output as", defaultextension=".mp4", filetypes=[("MP4", "*.mp4")])
-        if path:
-            self.var_output.set(path)
-
-    def browse_weights(self, _event: object | None = None) -> None:
-        path = filedialog.askdirectory(title="Select model folder")
-        if path:
-            self.var_weights.set(path)
-            self.cmb_weights.configure(values=[path, "Browse…"])
-            self.cmb_weights.set(path)
-        else:
-            self.cmb_weights.set(self.var_weights.get())
-
-    def browse_work(self, _event: object | None = None) -> None:
-        path = filedialog.askdirectory(title="Select work folder")
-        if path:
-            self.var_work.set(path)
-            self.cmb_work.configure(values=[path, "Browse…"])
-            self.cmb_work.set(path)
-        else:
-            self.cmb_work.set(self.var_work.get())
-
+    # Processing controls
     def collect_cfg(self) -> dict:
-        inp = self.var_input.get().strip()
-        out = self.var_output.get().strip()
+        inp = self.ed_in.text().strip()
+        out = self.ed_out.text().strip()
         if not inp:
             raise RuntimeError("Please set an input (file or YouTube URL).")
         if not out:
             raise RuntimeError("Please choose an output file.")
-        return {
-            "input": inp,
-            "output": out,
-            "target_width": int(self.var_w.get()),
-            "target_height": int(self.var_h.get()),
-            "weights_dir": self.var_weights.get().strip(),
-            "workdir": self.var_work.get().strip(),
-            "tile": int(self.var_tile.get()),
-            "cq": int(self.var_cq.get()),
-            "nvenc_codec": self.var_codec.get(),
-            "preset": self.var_preset.get(),
-            "use_fp16": bool(self.var_fp16.get()),
-            "keep_temps": bool(self.var_keep_temps.get()),
-            "prefetch_models": bool(self.var_prefetch.get()),
-            "strict_model_hash": bool(self.var_strict_hash.get()),
-        }
-
-    def apply_options(self) -> None:
-        """Update widgets from saved options."""
-        self.var_output.set(self.opts["output"])
-        self.var_w.set(int(self.opts["target_width"]))
-        self.var_h.set(int(self.opts["target_height"]))
-        self.var_weights.set(self.opts["weights_dir"])
-        self.cmb_weights.configure(values=[self.var_weights.get(), "Browse…"])
-        self.cmb_weights.set(self.var_weights.get())
-        self.var_work.set(self.opts["workdir"])
-        self.cmb_work.configure(values=[self.var_work.get(), "Browse…"])
-        self.cmb_work.set(self.var_work.get())
-        self.var_tile.set(int(self.opts["tile"]))
-        self.var_cq.set(int(self.opts["cq"]))
-        self.var_codec.set(self.opts["codec"])
-        self.var_preset.set(self.opts["preset"])
-        self.var_fp16.set(bool(self.opts["use_fp16"]))
-        self.var_keep_temps.set(bool(self.opts["keep_temps"]))
-        self.var_prefetch.set(bool(self.opts["prefetch_models"]))
-        self.var_strict_hash.set(bool(self.opts["strict_model_hash"]))
-        logger.debug("Applied options to UI")
-
-    def open_options(self) -> None:
-        if getattr(self, "opt_win", None):
-            self.opt_win.lift()
-            return
-        self.opt_win = ctk.CTkToplevel(self.root)
-        self.opt_win.title("Options")
-        logger.debug("Options window opened")
-        tab = ctk.CTkTabview(self.opt_win)
-        tab.pack(fill="both", expand=True, padx=10, pady=10)
-        paths = tab.add("Paths")
-        advanced = tab.add("Encoding")
-
-        vars_map = {
-            "output": (ctk.StringVar(value=self.opts["output"]), "Default output", paths),
-            "weights_dir": (ctk.StringVar(value=self.opts["weights_dir"]), "Weights folder", paths),
-            "workdir": (ctk.StringVar(value=self.opts["workdir"]), "Work folder", paths),
-            "target_width": (ctk.IntVar(value=self.opts["target_width"]), "Width", advanced),
-            "target_height": (ctk.IntVar(value=self.opts["target_height"]), "Height", advanced),
-            "tile": (ctk.IntVar(value=self.opts["tile"]), "Tile", advanced),
-            "cq": (ctk.IntVar(value=self.opts["cq"]), "CQ", advanced),
-            "codec": (ctk.StringVar(value=self.opts["codec"]), "Codec", advanced),
-            "preset": (ctk.StringVar(value=self.opts["preset"]), "Preset", advanced),
-            "use_fp16": (ctk.BooleanVar(value=self.opts["use_fp16"]), "Use FP16", advanced),
-            "keep_temps": (ctk.BooleanVar(value=self.opts["keep_temps"]), "Keep temps", advanced),
-            "prefetch_models": (ctk.BooleanVar(value=self.opts["prefetch_models"]), "Prefetch models", advanced),
-            "strict_model_hash": (ctk.BooleanVar(value=self.opts["strict_model_hash"]), "Strict hash", advanced),
-        }
-        self.opt_vars = {k: v[0] for k, v in vars_map.items()}
-
-        rows = {}
-        for key, (var, label, frame) in vars_map.items():
-            r = rows.setdefault(frame, 0)
-            if isinstance(var, ctk.BooleanVar):
-                ctk.CTkCheckBox(frame, text=label, variable=var).grid(row=r, column=0, sticky="w", padx=6, pady=2, columnspan=2)
-            else:
-                ctk.CTkLabel(frame, text=label).grid(row=r, column=0, sticky="e", padx=6, pady=2)
-                ctk.CTkEntry(frame, textvariable=var, width=200).grid(row=r, column=1, sticky="w", padx=6, pady=2)
-            rows[frame] += 1
-
-        frm_btn = ctk.CTkFrame(self.opt_win)
-        frm_btn.pack(pady=6)
-        ctk.CTkButton(frm_btn, text="Defaults", command=self.reset_options).pack(side="left", padx=4)
-        ctk.CTkButton(frm_btn, text="Save", command=self.save_options).pack(side="left", padx=4)
-        ctk.CTkButton(frm_btn, text="Close", command=self.close_options).pack(side="left", padx=4)
-
-    def reset_options(self) -> None:
-        for k, var in self.opt_vars.items():
-            var.set(DEFAULTS[k])
-        logger.debug("Options reset to defaults")
-
-    def save_options(self) -> None:
-        for k, var in self.opt_vars.items():
-            self.opts[k] = var.get()
-        save_options(self.opts)
-        self.apply_options()
-        logger.debug("Options saved")
-
-    def close_options(self) -> None:
-        if getattr(self, "opt_win", None):
-            self.opt_win.destroy()
-            self.opt_win = None
-            logger.debug("Options window closed")
+        cfg = self.opts.copy()
+        cfg.update({"input": inp, "output": out})
+        return cfg
 
     def start(self) -> None:
         try:
             cfg = self.collect_cfg()
         except Exception as e:
-            messagebox.showerror("Invalid settings", str(e))
+            QtWidgets.QMessageBox.critical(self, "Invalid settings", str(e))
             logger.error("Invalid settings: %s", e)
             return
-
-        logger.info("Starting processing")
-        self.btn_run.config(state="disabled")
-        self.btn_cancel.config(state="normal")
+        self.btn_start.setEnabled(False)
+        self.btn_cancel.setEnabled(True)
+        self.bar_dl.setValue(0)
+        self.bar_proc.setValue(0)
+        self.log_widget.clear()
         self.set_status("Starting…")
-        self.bar_dl.set(0)
-        self.bar_proc.set(0)
-        self.txt_log.delete("1.0", "end")
-
         self.processor = Processor(self)
-        t = threading.Thread(target=self.processor.run, args=(cfg,), daemon=True)
-        t.start()
+        self.thread = threading.Thread(target=self.processor.run, args=(cfg,), daemon=True)
+        self.thread.start()
         logger.debug("Processing thread launched")
 
     def cancel(self) -> None:
@@ -450,60 +288,23 @@ class App:
             self.processor.cancel()
             self.set_status("Cancelling…")
             logger.info("Cancel requested")
-        self.btn_cancel.config(state="disabled")
-        self.btn_run.config(state="normal")
-        logger.debug("Cancel handler completed")
+        self.btn_cancel.setEnabled(False)
+        self.btn_start.setEnabled(True)
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # type: ignore[override]
+        if self.processor:
+            self.processor.cancel()
+        event.accept()
 
 
 def main() -> None:
-    ctk.set_appearance_mode("Dark")
-    logger.info("Launching GUI")
-    root = ctk.CTk()
-    root.withdraw()
-
-    orig_destroy = root.destroy
-    orig_quit = root.quit
-
-    def report_callback_exception(exc: type[BaseException], val: BaseException, tb: object) -> None:
-        logger.exception("Tkinter callback error", exc_info=(exc, val, tb))
-        messagebox.showerror("Error", f"{exc.__name__}: {val}")
-
-    def logged_destroy(*args: object, **kwargs: object) -> None:
-        logger.debug("root.destroy called", stack_info=True)
-        return orig_destroy(*args, **kwargs)
-
-    def logged_quit(*args: object, **kwargs: object) -> None:
-        logger.debug("root.quit called", stack_info=True)
-        return orig_quit(*args, **kwargs)
-
-    root.bind("<Destroy>", lambda e: logger.debug("<Destroy> event for %s", e.widget))
-
-    root.report_callback_exception = report_callback_exception  # type: ignore[attr-defined]
-    root.destroy = logged_destroy  # type: ignore[assignment]
-    root.quit = logged_quit  # type: ignore[assignment]
-
-    if not preload(root):
-        logger.info("Startup cancelled")
-        root.destroy()
-        return
-
-    root.deiconify()
-    root.lift()
-    root.attributes("-topmost", True)
-    root.after(0, root.attributes, "-topmost", False)
-
-    def on_close() -> None:
-        logger.info("Window close requested")
-        root.destroy()
-
-    root.protocol("WM_DELETE_WINDOW", on_close)
-    app = App(root)
-    root.minsize(720, 600)
+    app = QtWidgets.QApplication(sys.argv)
+    win = MainWindow()
+    win.resize(800, 600)
+    win.show()
     logger.info("Entering mainloop")
-    try:
-        root.mainloop()
-    finally:
-        logger.info("GUI closed")
+    app.exec_()
+    logger.info("GUI closed")
 
 
 if __name__ == "__main__":

--- a/lynx/gui.py
+++ b/lynx/gui.py
@@ -5,7 +5,12 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-import customtkinter as ctk
+try:
+    import customtkinter as ctk
+except Exception as e:  # pragma: no cover - import failure check
+    raise RuntimeError(
+        "customtkinter is required for the GUI. Install it with 'pip install customtkinter'."
+    ) from e
 import tkinter as tk
 from tkinter import filedialog, messagebox
 import logging

--- a/lynx/gui.py
+++ b/lynx/gui.py
@@ -5,17 +5,18 @@ import threading
 from pathlib import Path
 from typing import Optional
 
+import customtkinter as ctk
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, messagebox
 
 
 class Tooltip:
-    """Simple tooltip for Tk widgets."""
+    """Simple tooltip for widgets."""
 
-    def __init__(self, widget: tk.Widget, text: str) -> None:
+    def __init__(self, widget: ctk.CTkBaseClass, text: str) -> None:
         self.widget = widget
         self.text = text
-        self.tip: Optional[tk.Toplevel] = None
+        self.tip: Optional[ctk.CTkToplevel] = None
         widget.bind("<Enter>", self.show)
         widget.bind("<Leave>", self.hide)
 
@@ -24,10 +25,10 @@ class Tooltip:
             return
         x = self.widget.winfo_rootx() + 20
         y = self.widget.winfo_rooty() + self.widget.winfo_height() + 10
-        self.tip = tk.Toplevel(self.widget)
+        self.tip = ctk.CTkToplevel(self.widget)
         self.tip.wm_overrideredirect(True)
         self.tip.wm_geometry(f"+{x}+{y}")
-        tk.Label(self.tip, text=self.text, background="#ffffe0", relief="solid", borderwidth=1, padx=4, pady=2).pack()
+        ctk.CTkLabel(self.tip, text=self.text, fg_color="#ffffe0", text_color="black", corner_radius=2).pack(padx=4, pady=2)
 
     def hide(self, _event: object | None = None) -> None:
         if self.tip:
@@ -43,23 +44,24 @@ from .options import load_options, save_options, DEFAULTS
 class SplashScreen:
     """Simple splash window with status text, progress bar and cancel."""
 
-    def __init__(self, root: tk.Tk, cancel_event: threading.Event) -> None:
+    def __init__(self, root: ctk.CTk, cancel_event: threading.Event) -> None:
         self.cancel_event = cancel_event
-        self.top = tk.Toplevel(root)
+        self.top = ctk.CTkToplevel(root)
         self.top.title("Lynx Loading")
         self.top.resizable(False, False)
         self.top.geometry("360x120")
         self.top.attributes("-topmost", True)
-        self.var_msg = tk.StringVar(value="Starting…")
-        tk.Label(self.top, textvariable=self.var_msg).pack(pady=10)
-        self.bar = ttk.Progressbar(self.top, maximum=100, length=300)
+        self.var_msg = ctk.StringVar(value="Starting…")
+        ctk.CTkLabel(self.top, textvariable=self.var_msg).pack(pady=10)
+        self.bar = ctk.CTkProgressBar(self.top, width=300)
         self.bar.pack(pady=10)
-        tk.Button(self.top, text="Cancel", command=self.cancel).pack(pady=(0, 8))
+        self.bar.set(0)
+        ctk.CTkButton(self.top, text="Cancel", command=self.cancel).pack(pady=(0, 8))
         self.top.update()
 
     def update(self, msg: str, value: int) -> None:
         self.var_msg.set(msg)
-        self.bar["value"] = value
+        self.bar.set(value / 100)
         self.top.update_idletasks()
 
     def cancel(self) -> None:
@@ -71,7 +73,7 @@ class SplashScreen:
         self.top.destroy()
 
 
-def preload(root: tk.Tk) -> bool:
+def preload(root: ctk.CTk) -> bool:
     """Show a temporary splash screen while verifying runtime.
 
     Returns ``True`` if startup completed, ``False`` if cancelled.
@@ -131,7 +133,7 @@ def preload(root: tk.Tk) -> bool:
 class App:
     """Main application window."""
 
-    def __init__(self, root: tk.Tk) -> None:
+    def __init__(self, root: ctk.CTk) -> None:
         self.root = root
         root.title("Lynx Upscaler")
         self.processor: Optional[Processor] = None
@@ -145,108 +147,110 @@ class App:
 
         pad = {"padx": 6, "pady": 2}
 
-        col1 = tk.Frame(root)
+        col1 = ctk.CTkFrame(root)
         col1.pack(fill="both", expand=True)
 
-        frm_in = tk.Frame(col1)
+        frm_in = ctk.CTkFrame(col1)
         frm_in.pack(fill="x", **pad)
-        self.var_input = tk.StringVar()
-        lbl_in = tk.Label(frm_in, text="Video file or YouTube link:")
+        self.var_input = ctk.StringVar()
+        lbl_in = ctk.CTkLabel(frm_in, text="Video file or YouTube link:")
         lbl_in.pack(anchor="w")
-        ent_in = tk.Entry(frm_in, textvariable=self.var_input, width=60)
+        ent_in = ctk.CTkEntry(frm_in, textvariable=self.var_input, width=400)
         ent_in.pack(side="left", fill="x", expand=True)
-        btn_in = tk.Button(frm_in, text="Browse", command=self.browse_input)
+        btn_in = ctk.CTkButton(frm_in, text="Browse", command=self.browse_input)
         btn_in.pack(side="left")
         Tooltip(ent_in, "Choose a local video or paste a YouTube URL")
 
-        frm_out = tk.Frame(col1)
+        frm_out = ctk.CTkFrame(col1)
         frm_out.pack(fill="x", **pad)
-        self.var_output = tk.StringVar(value=self.opts.get("output", DEFAULTS["output"]))
-        lbl_out = tk.Label(frm_out, text="Save output to:")
+        self.var_output = ctk.StringVar(value=self.opts.get("output", DEFAULTS["output"]))
+        lbl_out = ctk.CTkLabel(frm_out, text="Save output to:")
         lbl_out.pack(anchor="w")
-        ent_out = tk.Entry(frm_out, textvariable=self.var_output, width=60)
+        ent_out = ctk.CTkEntry(frm_out, textvariable=self.var_output, width=400)
         ent_out.pack(side="left", fill="x", expand=True)
-        btn_out = tk.Button(frm_out, text="Browse", command=self.browse_output)
+        btn_out = ctk.CTkButton(frm_out, text="Browse", command=self.browse_output)
         btn_out.pack(side="left")
         Tooltip(ent_out, "Destination video file")
 
-        frm_w = tk.Frame(col1)
+        frm_w = ctk.CTkFrame(col1)
         frm_w.pack(fill="x", **pad)
-        self.var_w = tk.IntVar(value=int(self.opts.get("target_width", DEFAULTS["target_width"])))
-        self.var_h = tk.IntVar(value=int(self.opts.get("target_height", DEFAULTS["target_height"])))
-        tk.Label(frm_w, text="Output width").grid(row=0, column=0, sticky="e")
-        ent_w = tk.Entry(frm_w, textvariable=self.var_w, width=6)
+        self.var_w = ctk.IntVar(value=int(self.opts.get("target_width", DEFAULTS["target_width"])))
+        self.var_h = ctk.IntVar(value=int(self.opts.get("target_height", DEFAULTS["target_height"])))
+        ctk.CTkLabel(frm_w, text="Output width").grid(row=0, column=0, sticky="e")
+        ent_w = ctk.CTkEntry(frm_w, textvariable=self.var_w, width=80)
         ent_w.grid(row=0, column=1, sticky="w")
-        tk.Label(frm_w, text="Height").grid(row=0, column=2, sticky="e")
-        ent_h = tk.Entry(frm_w, textvariable=self.var_h, width=6)
+        ctk.CTkLabel(frm_w, text="Height").grid(row=0, column=2, sticky="e")
+        ent_h = ctk.CTkEntry(frm_w, textvariable=self.var_h, width=80)
         ent_h.grid(row=0, column=3, sticky="w")
         Tooltip(ent_w, "Desired output width in pixels")
         Tooltip(ent_h, "Desired output height in pixels")
 
-        frm_paths = tk.Frame(col1)
+        frm_paths = ctk.CTkFrame(col1)
         frm_paths.pack(fill="x", **pad)
-        self.var_weights = tk.StringVar(value=self.opts.get("weights_dir", DEFAULTS["weights_dir"]))
-        self.var_work = tk.StringVar(value=self.opts.get("workdir", DEFAULTS["workdir"]))
-        tk.Label(frm_paths, text="Model folder").grid(row=0, column=0, sticky="e")
-        self.cmb_weights = ttk.Combobox(frm_paths, textvariable=self.var_weights, values=["Browse…"], width=40, state="readonly")
+        self.var_weights = ctk.StringVar(value=self.opts.get("weights_dir", DEFAULTS["weights_dir"]))
+        self.var_work = ctk.StringVar(value=self.opts.get("workdir", DEFAULTS["workdir"]))
+        ctk.CTkLabel(frm_paths, text="Model folder").grid(row=0, column=0, sticky="e")
+        self.cmb_weights = ctk.CTkComboBox(frm_paths, variable=self.var_weights, values=["Browse…"], width=200, state="readonly")
         self.cmb_weights.grid(row=0, column=1, sticky="w")
         self.cmb_weights.bind("<<ComboboxSelected>>", self.browse_weights)
         Tooltip(self.cmb_weights, "Where model weights are stored")
-        tk.Label(frm_paths, text="Work folder").grid(row=1, column=0, sticky="e")
-        self.cmb_work = ttk.Combobox(frm_paths, textvariable=self.var_work, values=["Browse…"], width=40, state="readonly")
+        ctk.CTkLabel(frm_paths, text="Work folder").grid(row=1, column=0, sticky="e")
+        self.cmb_work = ctk.CTkComboBox(frm_paths, variable=self.var_work, values=["Browse…"], width=200, state="readonly")
         self.cmb_work.grid(row=1, column=1, sticky="w")
         self.cmb_work.bind("<<ComboboxSelected>>", self.browse_work)
         Tooltip(self.cmb_work, "Temporary working directory")
 
-        frm_set = tk.Frame(col1)
+        frm_set = ctk.CTkFrame(col1)
         frm_set.pack(fill="x", **pad)
-        tk.Label(frm_set, text="Settings").grid(row=0, column=0, sticky="w", pady=(2, 6))
+        ctk.CTkLabel(frm_set, text="Settings").grid(row=0, column=0, sticky="w", pady=(2, 6))
 
-        self.var_tile = tk.IntVar(value=int(self.opts.get("tile", DEFAULTS["tile"])))
-        self.var_cq = tk.IntVar(value=int(self.opts.get("cq", DEFAULTS["cq"])))
-        self.var_codec = tk.StringVar(value=self.opts.get("codec", DEFAULTS["codec"]))
-        self.var_preset = tk.StringVar(value=self.opts.get("preset", DEFAULTS["preset"]))
-        self.var_fp16 = tk.BooleanVar(value=bool(self.opts.get("use_fp16", DEFAULTS["use_fp16"])))
-        self.var_keep_temps = tk.BooleanVar(value=bool(self.opts.get("keep_temps", DEFAULTS["keep_temps"])))
-        self.var_prefetch = tk.BooleanVar(value=bool(self.opts.get("prefetch_models", DEFAULTS["prefetch_models"])))
-        self.var_strict_hash = tk.BooleanVar(value=bool(self.opts.get("strict_model_hash", DEFAULTS["strict_model_hash"])))
+        self.var_tile = ctk.IntVar(value=int(self.opts.get("tile", DEFAULTS["tile"])))
+        self.var_cq = ctk.IntVar(value=int(self.opts.get("cq", DEFAULTS["cq"])))
+        self.var_codec = ctk.StringVar(value=self.opts.get("codec", DEFAULTS["codec"]))
+        self.var_preset = ctk.StringVar(value=self.opts.get("preset", DEFAULTS["preset"]))
+        self.var_fp16 = ctk.BooleanVar(value=bool(self.opts.get("use_fp16", DEFAULTS["use_fp16"])))
+        self.var_keep_temps = ctk.BooleanVar(value=bool(self.opts.get("keep_temps", DEFAULTS["keep_temps"])))
+        self.var_prefetch = ctk.BooleanVar(value=bool(self.opts.get("prefetch_models", DEFAULTS["prefetch_models"])))
+        self.var_strict_hash = ctk.BooleanVar(value=bool(self.opts.get("strict_model_hash", DEFAULTS["strict_model_hash"])))
 
-        tk.Label(frm_set, text="Tile").grid(row=1, column=0, sticky="e")
-        tk.Entry(frm_set, width=6, textvariable=self.var_tile).grid(row=1, column=1, sticky="w")
+        ctk.CTkLabel(frm_set, text="Tile").grid(row=1, column=0, sticky="e")
+        ctk.CTkEntry(frm_set, width=60, textvariable=self.var_tile).grid(row=1, column=1, sticky="w")
 
-        tk.Label(frm_set, text="CQ").grid(row=1, column=2, sticky="e")
-        tk.Entry(frm_set, width=6, textvariable=self.var_cq).grid(row=1, column=3, sticky="w")
+        ctk.CTkLabel(frm_set, text="CQ").grid(row=1, column=2, sticky="e")
+        ctk.CTkEntry(frm_set, width=60, textvariable=self.var_cq).grid(row=1, column=3, sticky="w")
 
-        tk.Label(frm_set, text="Codec").grid(row=2, column=0, sticky="e")
-        ttk.Combobox(frm_set, textvariable=self.var_codec, values=["hevc_nvenc", "h264_nvenc"], width=12, state="readonly").grid(row=2, column=1, sticky="w")
+        ctk.CTkLabel(frm_set, text="Codec").grid(row=2, column=0, sticky="e")
+        ctk.CTkComboBox(frm_set, variable=self.var_codec, values=["hevc_nvenc", "h264_nvenc"], width=120, state="readonly").grid(row=2, column=1, sticky="w")
 
-        tk.Label(frm_set, text="Preset").grid(row=2, column=2, sticky="e")
-        ttk.Combobox(frm_set, textvariable=self.var_preset, values=[f"p{i}" for i in range(1, 8)], width=6, state="readonly").grid(row=2, column=3, sticky="w")
+        ctk.CTkLabel(frm_set, text="Preset").grid(row=2, column=2, sticky="e")
+        ctk.CTkComboBox(frm_set, variable=self.var_preset, values=[f"p{i}" for i in range(1, 8)], width=60, state="readonly").grid(row=2, column=3, sticky="w")
 
-        tk.Checkbutton(frm_set, text="Use FP16 (RTX only)", variable=self.var_fp16).grid(row=3, column=0, sticky="w", pady=2)
-        tk.Checkbutton(frm_set, text="Keep temp files", variable=self.var_keep_temps).grid(row=3, column=1, sticky="w")
-        tk.Checkbutton(frm_set, text="Download models now", variable=self.var_prefetch).grid(row=3, column=2, sticky="w")
-        tk.Checkbutton(frm_set, text="Verify model hash", variable=self.var_strict_hash).grid(row=3, column=3, sticky="w")
+        ctk.CTkCheckBox(frm_set, text="Use FP16 (RTX only)", variable=self.var_fp16).grid(row=3, column=0, sticky="w", pady=2)
+        ctk.CTkCheckBox(frm_set, text="Keep temp files", variable=self.var_keep_temps).grid(row=3, column=1, sticky="w")
+        ctk.CTkCheckBox(frm_set, text="Download models now", variable=self.var_prefetch).grid(row=3, column=2, sticky="w")
+        ctk.CTkCheckBox(frm_set, text="Verify model hash", variable=self.var_strict_hash).grid(row=3, column=3, sticky="w")
 
-        frm_prog = tk.Frame(col1)
+        frm_prog = ctk.CTkFrame(col1)
         frm_prog.pack(fill="x", **pad)
-        tk.Label(frm_prog, text="Download progress").pack(anchor="w")
-        self.bar_dl = ttk.Progressbar(frm_prog, maximum=100)
+        ctk.CTkLabel(frm_prog, text="Download progress").pack(anchor="w")
+        self.bar_dl = ctk.CTkProgressBar(frm_prog)
         self.bar_dl.pack(fill="x")
-        tk.Label(frm_prog, text="Process progress").pack(anchor="w", pady=(8, 0))
-        self.bar_proc = ttk.Progressbar(frm_prog, maximum=100)
+        self.bar_dl.set(0)
+        ctk.CTkLabel(frm_prog, text="Process progress").pack(anchor="w", pady=(8, 0))
+        self.bar_proc = ctk.CTkProgressBar(frm_prog)
         self.bar_proc.pack(fill="x")
+        self.bar_proc.set(0)
 
-        self.var_status = tk.StringVar(value="Idle")
-        tk.Label(col1, textvariable=self.var_status).pack(anchor="w", **pad)
-        self.txt_log = tk.Text(col1, height=10)
+        self.var_status = ctk.StringVar(value="Idle")
+        ctk.CTkLabel(col1, textvariable=self.var_status).pack(anchor="w", **pad)
+        self.txt_log = ctk.CTkTextbox(col1, height=200)
         self.txt_log.pack(fill="both", expand=True, **pad)
 
-        frm_btn = tk.Frame(col1)
+        frm_btn = ctk.CTkFrame(col1)
         frm_btn.pack(fill="x", **pad)
-        self.btn_run = tk.Button(frm_btn, text="Start", command=self.start)
+        self.btn_run = ctk.CTkButton(frm_btn, text="Start", command=self.start)
         self.btn_run.pack(side="left")
-        self.btn_cancel = tk.Button(frm_btn, text="Cancel", command=self.cancel, state="disabled")
+        self.btn_cancel = ctk.CTkButton(frm_btn, text="Cancel", command=self.cancel, state="disabled")
         self.btn_cancel.pack(side="left", padx=6)
 
         self.apply_options()
@@ -261,9 +265,9 @@ class App:
             return
         value = max(0, min(100, int(done * 100 / total)))
         if which == "download":
-            self.bar_dl["value"] = value
+            self.bar_dl.set(value / 100)
         else:
-            self.bar_proc["value"] = value
+            self.bar_proc.set(value / 100)
         self.root.update_idletasks()
 
     def set_status(self, msg: str) -> None:
@@ -346,38 +350,45 @@ class App:
         if getattr(self, "opt_win", None):
             self.opt_win.lift()
             return
-        self.opt_win = tk.Toplevel(self.root)
+        self.opt_win = ctk.CTkToplevel(self.root)
         self.opt_win.title("Options")
+        tab = ctk.CTkTabview(self.opt_win)
+        tab.pack(fill="both", expand=True, padx=10, pady=10)
+        paths = tab.add("Paths")
+        advanced = tab.add("Encoding")
+
         vars_map = {
-            "output": (tk.StringVar(value=self.opts["output"]), "Default output"),
-            "weights_dir": (tk.StringVar(value=self.opts["weights_dir"]), "Weights folder"),
-            "workdir": (tk.StringVar(value=self.opts["workdir"]), "Work folder"),
-            "target_width": (tk.IntVar(value=self.opts["target_width"]), "Width"),
-            "target_height": (tk.IntVar(value=self.opts["target_height"]), "Height"),
-            "tile": (tk.IntVar(value=self.opts["tile"]), "Tile"),
-            "cq": (tk.IntVar(value=self.opts["cq"]), "CQ"),
-            "codec": (tk.StringVar(value=self.opts["codec"]), "Codec"),
-            "preset": (tk.StringVar(value=self.opts["preset"]), "Preset"),
-            "use_fp16": (tk.BooleanVar(value=self.opts["use_fp16"]), "Use FP16"),
-            "keep_temps": (tk.BooleanVar(value=self.opts["keep_temps"]), "Keep temps"),
-            "prefetch_models": (tk.BooleanVar(value=self.opts["prefetch_models"]), "Prefetch models"),
-            "strict_model_hash": (tk.BooleanVar(value=self.opts["strict_model_hash"]), "Strict hash"),
+            "output": (ctk.StringVar(value=self.opts["output"]), "Default output", paths),
+            "weights_dir": (ctk.StringVar(value=self.opts["weights_dir"]), "Weights folder", paths),
+            "workdir": (ctk.StringVar(value=self.opts["workdir"]), "Work folder", paths),
+            "target_width": (ctk.IntVar(value=self.opts["target_width"]), "Width", advanced),
+            "target_height": (ctk.IntVar(value=self.opts["target_height"]), "Height", advanced),
+            "tile": (ctk.IntVar(value=self.opts["tile"]), "Tile", advanced),
+            "cq": (ctk.IntVar(value=self.opts["cq"]), "CQ", advanced),
+            "codec": (ctk.StringVar(value=self.opts["codec"]), "Codec", advanced),
+            "preset": (ctk.StringVar(value=self.opts["preset"]), "Preset", advanced),
+            "use_fp16": (ctk.BooleanVar(value=self.opts["use_fp16"]), "Use FP16", advanced),
+            "keep_temps": (ctk.BooleanVar(value=self.opts["keep_temps"]), "Keep temps", advanced),
+            "prefetch_models": (ctk.BooleanVar(value=self.opts["prefetch_models"]), "Prefetch models", advanced),
+            "strict_model_hash": (ctk.BooleanVar(value=self.opts["strict_model_hash"]), "Strict hash", advanced),
         }
         self.opt_vars = {k: v[0] for k, v in vars_map.items()}
-        row = 0
-        for key, (var, label) in vars_map.items():
-            if isinstance(var, tk.BooleanVar):
-                tk.Checkbutton(self.opt_win, text=label, variable=var).grid(row=row, column=0, sticky="w", padx=6, pady=2, columnspan=2)
-            else:
-                tk.Label(self.opt_win, text=label).grid(row=row, column=0, sticky="e", padx=6, pady=2)
-                tk.Entry(self.opt_win, textvariable=var, width=30).grid(row=row, column=1, sticky="w", padx=6, pady=2)
-            row += 1
 
-        frm_btn = tk.Frame(self.opt_win)
-        frm_btn.grid(row=row, column=0, columnspan=2, pady=6)
-        tk.Button(frm_btn, text="Defaults", command=self.reset_options).pack(side="left", padx=4)
-        tk.Button(frm_btn, text="Save", command=self.save_options).pack(side="left", padx=4)
-        tk.Button(frm_btn, text="Close", command=self.close_options).pack(side="left", padx=4)
+        rows = {}
+        for key, (var, label, frame) in vars_map.items():
+            r = rows.setdefault(frame, 0)
+            if isinstance(var, ctk.BooleanVar):
+                ctk.CTkCheckBox(frame, text=label, variable=var).grid(row=r, column=0, sticky="w", padx=6, pady=2, columnspan=2)
+            else:
+                ctk.CTkLabel(frame, text=label).grid(row=r, column=0, sticky="e", padx=6, pady=2)
+                ctk.CTkEntry(frame, textvariable=var, width=200).grid(row=r, column=1, sticky="w", padx=6, pady=2)
+            rows[frame] += 1
+
+        frm_btn = ctk.CTkFrame(self.opt_win)
+        frm_btn.pack(pady=6)
+        ctk.CTkButton(frm_btn, text="Defaults", command=self.reset_options).pack(side="left", padx=4)
+        ctk.CTkButton(frm_btn, text="Save", command=self.save_options).pack(side="left", padx=4)
+        ctk.CTkButton(frm_btn, text="Close", command=self.close_options).pack(side="left", padx=4)
 
     def reset_options(self) -> None:
         for k, var in self.opt_vars.items():
@@ -404,8 +415,8 @@ class App:
         self.btn_run.config(state="disabled")
         self.btn_cancel.config(state="normal")
         self.set_status("Starting…")
-        self.bar_dl["value"] = 0
-        self.bar_proc["value"] = 0
+        self.bar_dl.set(0)
+        self.bar_proc.set(0)
         self.txt_log.delete("1.0", "end")
 
         self.processor = Processor(self)
@@ -421,7 +432,8 @@ class App:
 
 
 def main() -> None:
-    root = tk.Tk()
+    ctk.set_appearance_mode("Dark")
+    root = ctk.CTk()
     root.withdraw()
     if not preload(root):
         root.destroy()

--- a/lynx/logger.py
+++ b/lynx/logger.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+
+_logger = logging.getLogger("lynx")
+
+
+def setup() -> logging.Logger:
+    """Configure and return the shared Lynx logger."""
+    if not _logger.handlers:
+        _logger.setLevel(logging.DEBUG)
+        fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        fh = logging.FileHandler(LOG_DIR / "lynx.log", encoding="utf-8")
+        fh.setFormatter(fmt)
+        sh = logging.StreamHandler()
+        sh.setFormatter(fmt)
+        _logger.addHandler(fh)
+        _logger.addHandler(sh)
+    return _logger
+
+
+def get_logger() -> logging.Logger:
+    """Get the shared Lynx logger."""
+    return setup()

--- a/lynx/options.py
+++ b/lynx/options.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any, Dict
+from .logger import get_logger
+
+logger = get_logger()
 
 OPTIONS_DIR = Path("options")
 OPTIONS_FILE = OPTIONS_DIR / "settings.json"
@@ -32,9 +35,10 @@ def load_options() -> Dict[str, Any]:
             data = json.loads(OPTIONS_FILE.read_text())
             opts = DEFAULTS.copy()
             opts.update({k: data.get(k, v) for k, v in DEFAULTS.items()})
+            logger.debug("Loaded options from %s", OPTIONS_FILE)
             return opts
         except Exception:
-            pass
+            logger.exception("Failed to load options; using defaults")
     return DEFAULTS.copy()
 
 
@@ -42,3 +46,4 @@ def save_options(opts: Dict[str, Any]) -> None:
     """Persist options to disk."""
     OPTIONS_DIR.mkdir(exist_ok=True)
     OPTIONS_FILE.write_text(json.dumps(opts, indent=2))
+    logger.debug("Saved options to %s", OPTIONS_FILE)

--- a/lynx/options.py
+++ b/lynx/options.py
@@ -1,0 +1,44 @@
+"""Persistent options handling for Lynx GUI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+OPTIONS_DIR = Path("options")
+OPTIONS_FILE = OPTIONS_DIR / "settings.json"
+
+DEFAULTS: Dict[str, Any] = {
+    "output": str(Path("outputs") / "output.mp4"),
+    "weights_dir": str(Path("weights")),
+    "workdir": str(Path("work")),
+    "target_width": 3840,
+    "target_height": 2160,
+    "tile": 256,
+    "cq": 19,
+    "codec": "hevc_nvenc",
+    "preset": "p5",
+    "use_fp16": True,
+    "keep_temps": False,
+    "prefetch_models": True,
+    "strict_model_hash": False,
+}
+
+
+def load_options() -> Dict[str, Any]:
+    """Load saved options, falling back to defaults."""
+    if OPTIONS_FILE.exists():
+        try:
+            data = json.loads(OPTIONS_FILE.read_text())
+            opts = DEFAULTS.copy()
+            opts.update({k: data.get(k, v) for k, v in DEFAULTS.items()})
+            return opts
+        except Exception:
+            pass
+    return DEFAULTS.copy()
+
+
+def save_options(opts: Dict[str, Any]) -> None:
+    """Persist options to disk."""
+    OPTIONS_DIR.mkdir(exist_ok=True)
+    OPTIONS_FILE.write_text(json.dumps(opts, indent=2))

--- a/lynx/processor.py
+++ b/lynx/processor.py
@@ -7,7 +7,13 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-import cv2
+try:
+    import cv2  # type: ignore
+except Exception as e:  # pragma: no cover - allow starting GUI without cv2
+    cv2 = None  # type: ignore
+    CV2_IMPORT_ERROR = e
+else:
+    CV2_IMPORT_ERROR = None
 import torch
 
 from .download import is_url, yt_download
@@ -48,6 +54,10 @@ class Processor:
     def run(self, cfg: dict) -> None:
         """Entry point for the processing thread."""
         logger.info("Processing thread started")
+        if cv2 is None:
+            raise RuntimeError(
+                f"OpenCV is unavailable: {CV2_IMPORT_ERROR}. Please install opencv-python"
+            )
         try:
             self._log("Checking FFmpeg availability…")
             subprocess.run(["ffmpeg", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)

--- a/lynx/processor.py
+++ b/lynx/processor.py
@@ -14,6 +14,9 @@ from .download import is_url, yt_download
 from .encode import run_ffmpeg_encode
 from .models import ensure_model
 from .upscale import build_upsampler, pick_model
+from .logger import get_logger
+
+logger = get_logger()
 
 
 class UIHooks:
@@ -36,6 +39,7 @@ class Processor:
 
     # Internal helpers
     def _log(self, msg: str) -> None:
+        logger.info(msg)
         self.ui.log(msg)
 
     def _set_bar(self, which: str, done: int, total: int) -> None:
@@ -43,6 +47,7 @@ class Processor:
 
     def run(self, cfg: dict) -> None:
         """Entry point for the processing thread."""
+        logger.info("Processing thread started")
         try:
             self._log("Checking FFmpeg availability…")
             subprocess.run(["ffmpeg", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
@@ -194,3 +199,5 @@ class Processor:
                 cancel_event=self.cancel_event,
                 log_cb=self._log,
             )
+
+        logger.info("Processing finished")

--- a/main.py
+++ b/main.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import tkinter as tk
+from lynx.logger import get_logger
+
+logger = get_logger()
 
 
 def fatal(msg: str) -> None:
     """Show an error message with an Exit button and stop."""
+    logger.error(msg)
     root = tk.Tk()
     root.title("Lynx Error")
     tk.Label(root, text=msg, justify="left", wraplength=400).pack(padx=20, pady=10)
@@ -15,15 +19,18 @@ def fatal(msg: str) -> None:
 
 
 def safe_main() -> None:
+    logger.info("Starting Lynx")
     try:
         from lynx.gui import main as gui_main
     except Exception as e:  # pragma: no cover - GUI import failed
+        logger.exception("GUI import failed")
         fatal(f"Failed to start GUI: {e}")
         return
 
     try:
         gui_main()
     except Exception as e:  # pragma: no cover - runtime failure
+        logger.exception("Unhandled error")
         fatal(str(e))
 
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,31 @@
-"""Backward compatibility entry point."""
-from lynx.gui import main
+"""Entry point that gracefully reports fatal startup errors."""
+
+from __future__ import annotations
+
+import tkinter as tk
+
+
+def fatal(msg: str) -> None:
+    """Show an error message with an Exit button and stop."""
+    root = tk.Tk()
+    root.title("Lynx Error")
+    tk.Label(root, text=msg, justify="left", wraplength=400).pack(padx=20, pady=10)
+    tk.Button(root, text="Exit", command=root.destroy).pack(pady=(0, 10))
+    root.mainloop()
+
+
+def safe_main() -> None:
+    try:
+        from lynx.gui import main as gui_main
+    except Exception as e:  # pragma: no cover - GUI import failed
+        fatal(f"Failed to start GUI: {e}")
+        return
+
+    try:
+        gui_main()
+    except Exception as e:  # pragma: no cover - runtime failure
+        fatal(str(e))
+
 
 if __name__ == "__main__":
-    main()
+    safe_main()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import tkinter as tk
+from PyQt5 import QtWidgets
 from lynx.logger import get_logger
 
 logger = get_logger()
@@ -11,11 +11,9 @@ logger = get_logger()
 def fatal(msg: str) -> None:
     """Show an error message with an Exit button and stop."""
     logger.error(msg)
-    root = tk.Tk()
-    root.title("Lynx Error")
-    tk.Label(root, text=msg, justify="left", wraplength=400).pack(padx=20, pady=10)
-    tk.Button(root, text="Exit", command=root.destroy).pack(pady=(0, 10))
-    root.mainloop()
+    app = QtWidgets.QApplication([])
+    QtWidgets.QMessageBox.critical(None, "Lynx Error", msg)
+    app.exec_()
 
 
 def safe_main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ yt-dlp>=2024.7
 realesrgan>=0.3.0
 # Use the upstream BasicSR (avoids torchvision import issues)
 basicsr @ git+https://github.com/XPixelGroup/BasicSR@master
-customtkinter>=5.2
+PyQt5>=5.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ yt-dlp>=2024.7
 realesrgan>=0.3.0
 # Use the upstream BasicSR (avoids torchvision import issues)
 basicsr @ git+https://github.com/XPixelGroup/BasicSR@master
+customtkinter>=5.2


### PR DESCRIPTION
## Summary
- default output path set to `outputs/output.mp4`
- make model and work directory fields dropdowns
- add helpful tooltips and improved wording
- enable model prefetch by default
- persist settings in an `options` folder with a Reset button

## Testing
- `python tests/tester.py`


------
https://chatgpt.com/codex/tasks/task_e_6886c85e6f2c832eb58d1f9283f05c3e