### PR TITLE
Add YouTube preloader interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Lynx
 
-Local YouTube upscaling toolkit using Real‑ESRGAN and NVENC.  The
-application ships with a PyQt5 interface that stores its settings under your
-OS configuration directory, e.g. `~/.config/lynx/settings.json` or
-`%LOCALAPPDATA%\Lynx\settings.json`.
+Lynx now focuses on preloading YouTube videos for smooth offline playback.
+Given a URL the tool downloads the entire stream to disk and immediately
+upscales it with Real‑ESRGAN before handing the result to FFmpeg for fast
+NVENC encoding.  The legacy GUI is still available, but the recommended entry
+point is the new preloader CLI.
 
 ## Quick start
 
@@ -14,17 +15,14 @@ OS configuration directory, e.g. `~/.config/lynx/settings.json` or
    bash setup.sh
    ```
    The log of all actions is saved to `setup/setup.log` for troubleshooting (git ignores this file by default).
-3. Activate the environment and start the GUI:
+3. Activate the environment and run the preloader CLI:
    ```bash
    conda activate lynx
-   python main.py
+   python -m lynx.cli "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
    ```
-   The window shows a status box indicating whether CUDA and the required weights are detected. If you see "GPU detected but PyTorch CPU-only" follow the reinstall notes below.
-4. For headless use, run the CLI:
-   ```bash
-   python -m lynx.cli -h
-   ```
-   The CLI accepts the same options as the GUI.
+   The command downloads the video, upscales it according to your chosen
+   dimensions and writes the result to the `outputs/` directory.  Use
+   `python -m lynx.cli -h` to see all available options.
 
 ## Directory layout
 

--- a/lynx/__init__.py
+++ b/lynx/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "upscale",
     "encode",
     "processor",
+    "preloader",
     "gui",
     "cli",
 ]

--- a/lynx/cli.py
+++ b/lynx/cli.py
@@ -4,73 +4,112 @@ import argparse
 import sys
 
 from .options import DEFAULTS
-from .logger import get_logger
-
-
-class CLIHooks:
-    """Console-based hooks for :class:`Processor`."""
-
-    def __init__(self) -> None:
-        self.logger = get_logger()
-
-    def log(self, msg: str) -> None:
-        self.logger.info(msg)
-
-    def set_progress(self, which: str, done: int, total: int) -> None:
-        if total > 0:
-            pct = int(done / total * 100)
-            self.logger.info("%s %d%% (%d/%d)", which, pct, done, total)
-
-    def set_status(self, msg: str) -> None:
-        self.logger.info(msg)
+from .preloader import ConsolePreloadHooks, PreloadConfig, VideoPreloader
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Return parsed command-line arguments."""
-    p = argparse.ArgumentParser(description="Headless Lynx video upscaler")
-    p.add_argument("input", help="input video file or URL")
-    p.add_argument("-o", "--output", default=DEFAULTS["output"], help="output file")
-    p.add_argument("--width", type=int, default=DEFAULTS["target_width"], help="target width")
-    p.add_argument("--height", type=int, default=DEFAULTS["target_height"], help="target height")
-    p.add_argument("--tile", type=int, default=DEFAULTS["tile"], help="tile size")
-    p.add_argument("--cq", type=int, default=DEFAULTS["cq"], help="NVENC constant quality")
-    p.add_argument("--codec", default=DEFAULTS["codec"], help="FFmpeg codec")
-    p.add_argument("--preset", default=DEFAULTS["preset"], help="NVENC preset")
-    p.add_argument("--weights-dir", default=DEFAULTS["weights_dir"], help="Real-ESRGAN weights directory")
-    p.add_argument("--workdir", default=DEFAULTS["workdir"], help="temporary working directory")
-    p.add_argument("--fp16", action="store_true", default=DEFAULTS["use_fp16"], help="use fp16 upscaling")
-    p.add_argument("--keep-temps", action="store_true", default=DEFAULTS["keep_temps"], help="keep temporary files")
-    p.add_argument("--no-prefetch", dest="prefetch_models", action="store_false", default=DEFAULTS["prefetch_models"], help="skip model download")
-    p.add_argument("--strict-model-hash", action="store_true", default=DEFAULTS["strict_model_hash"], help="fail on weight checksum mismatch")
+    """Return parsed command-line arguments for the preloader CLI."""
+
+    p = argparse.ArgumentParser(
+        description="Download a YouTube video ahead of time and upscale it locally.",
+    )
+    p.add_argument(
+        "url",
+        help="YouTube video URL or path to a pre-downloaded video",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default=DEFAULTS["output"],
+        help="Destination file for the upscaled video",
+    )
+    p.add_argument(
+        "--width",
+        type=int,
+        default=DEFAULTS["target_width"],
+        help="Target width for the upscaled output",
+    )
+    p.add_argument(
+        "--height",
+        type=int,
+        default=DEFAULTS["target_height"],
+        help="Target height for the upscaled output",
+    )
+    p.add_argument(
+        "--tile",
+        type=int,
+        default=DEFAULTS["tile"],
+        help="Tile size for Real-ESRGAN inference",
+    )
+    p.add_argument(
+        "--cq",
+        type=int,
+        default=DEFAULTS["cq"],
+        help="NVENC constant quality setting",
+    )
+    p.add_argument(
+        "--codec",
+        default=DEFAULTS["codec"],
+        help="FFmpeg video codec to use",
+    )
+    p.add_argument(
+        "--preset",
+        default=DEFAULTS["preset"],
+        help="NVENC preset to use",
+    )
+    p.add_argument(
+        "--weights-dir",
+        default=DEFAULTS["weights_dir"],
+        help="Directory where Real-ESRGAN model weights are stored",
+    )
+    p.add_argument(
+        "--workdir",
+        default=DEFAULTS["workdir"],
+        help="Working directory for downloads and temporary data",
+    )
+    p.add_argument(
+        "--fp16",
+        action=argparse.BooleanOptionalAction,
+        default=DEFAULTS["use_fp16"],
+        help="Toggle fp16 inference when CUDA is available",
+    )
+    p.add_argument(
+        "--keep-temps",
+        action="store_true",
+        default=DEFAULTS["keep_temps"],
+        help="Keep intermediate temporary files",
+    )
+    p.add_argument(
+        "--prefetch-models",
+        action=argparse.BooleanOptionalAction,
+        default=DEFAULTS["prefetch_models"],
+        help="Pre-download Real-ESRGAN weights before processing",
+    )
+    p.add_argument(
+        "--strict-model-hash",
+        action="store_true",
+        default=DEFAULTS["strict_model_hash"],
+        help="Abort when a weight checksum mismatch is detected",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
-    from .processor import Processor
-    cfg = {
-        "input": args.input,
-        "output": args.output,
-        "target_width": args.width,
-        "target_height": args.height,
-        "tile": args.tile,
-        "cq": args.cq,
-        "codec": args.codec,
-        "preset": args.preset,
-        "weights_dir": args.weights_dir,
-        "workdir": args.workdir,
-        "use_fp16": args.fp16,
-        "keep_temps": args.keep_temps,
-        "prefetch_models": args.prefetch_models,
-        "strict_model_hash": args.strict_model_hash,
-    }
-    hooks = CLIHooks()
-    proc = Processor(hooks)
+    hooks = ConsolePreloadHooks()
+    config = PreloadConfig.from_args(args)
+    preloader = VideoPreloader(config, hooks=hooks)
+
     try:
-        proc.run(cfg)
+        result = preloader.prepare()
     except Exception as exc:  # pragma: no cover - runtime errors
         hooks.log(f"Error: {exc}")
         sys.exit(1)
+
+    w, h = result.output_resolution
+    hooks.log(
+        f"Finished preloading {result.output_path} ({w}x{h}) in {result.elapsed_seconds:.2f} s",
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/lynx/preloader.py
+++ b/lynx/preloader.py
@@ -1,0 +1,135 @@
+"""High-level helpers for the YouTube preloader workflow."""
+from __future__ import annotations
+
+from argparse import Namespace
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, TYPE_CHECKING
+
+from .logger import get_logger
+from .options import DEFAULTS
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from .processor import ProcessingResult
+else:  # pragma: no cover - fallback when heavy deps are unavailable
+    ProcessingResult = Any  # type: ignore[misc]
+
+
+@dataclass
+class PreloadConfig:
+    """Configuration describing a preload job."""
+
+    url: str
+    output_path: Path = Path(DEFAULTS["output"])
+    target_width: int = DEFAULTS["target_width"]
+    target_height: int = DEFAULTS["target_height"]
+    workdir: Path = Path(DEFAULTS["workdir"])
+    weights_dir: Path = Path(DEFAULTS["weights_dir"])
+    tile: int = DEFAULTS["tile"]
+    cq: int = DEFAULTS["cq"]
+    codec: str = DEFAULTS["codec"]
+    preset: str = DEFAULTS["preset"]
+    use_fp16: bool = DEFAULTS["use_fp16"]
+    keep_temps: bool = DEFAULTS["keep_temps"]
+    prefetch_models: bool = DEFAULTS["prefetch_models"]
+    strict_model_hash: bool = DEFAULTS["strict_model_hash"]
+
+    def __post_init__(self) -> None:
+        if not self.url:
+            raise ValueError("A YouTube URL or local path must be provided")
+        if self.target_width <= 0 or self.target_height <= 0:
+            raise ValueError("Target dimensions must be positive integers")
+        if self.tile <= 0:
+            raise ValueError("Tile size must be a positive integer")
+        if self.cq < 0:
+            raise ValueError("Constant quality cannot be negative")
+        if not self.codec:
+            raise ValueError("Codec must be specified")
+        if not self.preset:
+            raise ValueError("Preset must be specified")
+
+        self.output_path = Path(self.output_path).expanduser().resolve()
+        self.workdir = Path(self.workdir).expanduser().resolve()
+        self.weights_dir = Path(self.weights_dir).expanduser().resolve()
+
+    @classmethod
+    def from_args(cls, args: Namespace) -> "PreloadConfig":
+        """Create a configuration object from CLI arguments."""
+
+        return cls(
+            url=args.url,
+            output_path=Path(args.output),
+            target_width=args.width,
+            target_height=args.height,
+            workdir=Path(args.workdir),
+            weights_dir=Path(args.weights_dir),
+            tile=args.tile,
+            cq=args.cq,
+            codec=args.codec,
+            preset=args.preset,
+            use_fp16=args.fp16,
+            keep_temps=args.keep_temps,
+            prefetch_models=args.prefetch_models,
+            strict_model_hash=args.strict_model_hash,
+        )
+
+    def to_processor_config(self) -> dict[str, object]:
+        """Convert the config into the dictionary expected by ``Processor``."""
+
+        return {
+            "input": self.url,
+            "output": str(self.output_path),
+            "target_width": int(self.target_width),
+            "target_height": int(self.target_height),
+            "tile": int(self.tile),
+            "cq": int(self.cq),
+            "codec": self.codec,
+            "preset": self.preset,
+            "weights_dir": str(self.weights_dir),
+            "workdir": str(self.workdir),
+            "use_fp16": bool(self.use_fp16),
+            "keep_temps": bool(self.keep_temps),
+            "prefetch_models": bool(self.prefetch_models),
+            "strict_model_hash": bool(self.strict_model_hash),
+        }
+
+
+PreloadResult = ProcessingResult
+
+
+class ConsolePreloadHooks:
+    """Default hooks that log progress through :mod:`logging`."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger()
+
+    def log(self, msg: str) -> None:  # pragma: no cover - pass-through to logger
+        self.logger.info(msg)
+
+    def set_progress(self, which: str, done: int, total: int) -> None:
+        if total > 0:
+            pct = int(done / total * 100)
+            self.logger.info("%s %d%% (%d/%d)", which, pct, done, total)
+        else:
+            self.logger.info("%s %d", which, done)
+
+    def set_status(self, msg: str) -> None:
+        self.logger.info(msg)
+
+
+class VideoPreloader:
+    """Coordinate downloading, upscaling and encoding."""
+
+    def __init__(self, config: PreloadConfig, hooks: Optional[Any] = None) -> None:
+        self.config = config
+        self.hooks = hooks or ConsolePreloadHooks()
+        from .processor import Processor
+
+        self._processor = Processor(self.hooks)  # heavy import deferred until needed
+
+    def prepare(self) -> PreloadResult:
+        """Execute the preloading pipeline and return a summary."""
+        summary = self._processor.run(self.config.to_processor_config())
+        if not summary.output_path.exists():
+            raise RuntimeError(f"Upscaled video missing: {summary.output_path}")
+        return summary

--- a/lynx/processor.py
+++ b/lynx/processor.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 import math
+import shutil
 import subprocess
 import threading
+from dataclasses import dataclass
 from pathlib import Path
+from time import perf_counter
 from typing import Optional
 
 try:
@@ -23,6 +26,18 @@ from .upscale import build_upsampler, pick_model
 from .logger import get_logger
 
 logger = get_logger()
+
+
+@dataclass
+class ProcessingResult:
+    """Summary returned by :meth:`Processor.run`."""
+
+    source_path: Path
+    output_path: Path
+    output_resolution: tuple[int, int]
+    fps: float
+    processed_frames: Optional[int]
+    elapsed_seconds: float
 
 
 class UIHooks:
@@ -50,9 +65,10 @@ class Processor:
     def _set_bar(self, which: str, done: int, total: int) -> None:
         self.ui.set_progress(which, done, total)
 
-    def run(self, cfg: dict) -> None:
+    def run(self, cfg: dict) -> ProcessingResult:
         """Entry point for the processing thread."""
         logger.info("Processing thread started")
+        start_time = perf_counter()
         if cv2 is None:
             raise RuntimeError(
                 f"OpenCV is unavailable: {CV2_IMPORT_ERROR}. Please install opencv-python"
@@ -135,7 +151,10 @@ class Processor:
                 log_cb=self._log,
             )
 
+        processed_frames: Optional[int] = None
+
         def frames_iter():
+            nonlocal processed_frames
             fidx = 0
             while True:
                 if self.cancel_event.is_set():
@@ -148,6 +167,7 @@ class Processor:
                 if nframes:
                     self._set_bar("process", fidx, nframes)
                 self.ui.set_status(f"Reading… {fidx}/{nframes or '?'}")
+                processed_frames = fidx
                 yield rgb
             cap.release()
 
@@ -185,6 +205,7 @@ class Processor:
                 self._log("⚠ Running on CPU; this will be slow.")
 
             def upscaled_frames():
+                nonlocal processed_frames
                 fidx = 0
                 self._log("Upscaling…")
                 while True:
@@ -201,6 +222,7 @@ class Processor:
                     if nframes:
                         self._set_bar("process", fidx, nframes)
                     self.ui.set_status(f"SR… {fidx}/{nframes or '?'}")
+                    processed_frames = fidx
                     yield sr
                 cap.release()
 
@@ -217,4 +239,25 @@ class Processor:
                 log_cb=self._log,
             )
 
+        if processed_frames is None and nframes:
+            processed_frames = nframes
+
+        elapsed = perf_counter() - start_time
+
+        if not cfg.get("keep_temps"):
+            try:
+                if temp_dir.exists():
+                    shutil.rmtree(temp_dir)
+                    self._log(f"Cleaned temporary files under {temp_dir}")
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                self._log(f"⚠ Failed to clean temporary files: {exc}")
+
         logger.info("Processing finished")
+        return ProcessingResult(
+            source_path=inp_path,
+            output_path=out_path,
+            output_resolution=(out_w, out_h),
+            fps=fps,
+            processed_frames=processed_frames,
+            elapsed_seconds=elapsed,
+        )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,10 +90,46 @@ class TestHelpers(unittest.TestCase):
     def test_cli_parse_args(self):
         from lynx.cli import parse_args
 
-        args = parse_args(["in.mp4", "-o", "out.mp4", "--width", "1280"])
-        self.assertEqual(args.input, "in.mp4")
+        args = parse_args([
+            "https://example.com/watch?v=1",
+            "-o",
+            "out.mp4",
+            "--width",
+            "1280",
+            "--no-fp16",
+            "--no-prefetch-models",
+        ])
+        self.assertEqual(args.url, "https://example.com/watch?v=1")
         self.assertEqual(args.output, "out.mp4")
         self.assertEqual(args.width, 1280)
+        self.assertFalse(args.fp16)
+        self.assertFalse(args.prefetch_models)
+
+    def test_preload_config_to_processor(self):
+        from lynx.preloader import PreloadConfig
+
+        cfg = PreloadConfig(
+            url="https://example.com/watch?v=test",
+            output_path=Path("outputs/custom.mp4"),
+            target_width=1920,
+            target_height=1080,
+            workdir=Path("work/custom"),
+            weights_dir=Path("weights/custom"),
+            tile=128,
+            cq=15,
+            codec="h264_nvenc",
+            preset="p4",
+            use_fp16=False,
+            keep_temps=True,
+            prefetch_models=False,
+            strict_model_hash=True,
+        )
+        proc_cfg = cfg.to_processor_config()
+        self.assertEqual(proc_cfg["input"], cfg.url)
+        self.assertEqual(proc_cfg["output"], str(cfg.output_path))
+        self.assertEqual(proc_cfg["workdir"], str(Path("work/custom").expanduser().resolve()))
+        self.assertFalse(proc_cfg["prefetch_models"])
+        self.assertTrue(proc_cfg["keep_temps"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- highlight the new YouTube preloader workflow in the documentation
- add a reusable PreloadConfig/VideoPreloader layer and return structured results from Processor
- refresh the CLI and tests to exercise the preloader configuration pipeline
- remove the unused HookProtocol layer from the preloader implementation

## Testing
- python tests/tester.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f9ee3d88832e9ac9952ceb32cb5e